### PR TITLE
Added the open command to open a jira issue in a browser

### DIFF
--- a/bin/jira.js
+++ b/bin/jira.js
@@ -167,6 +167,17 @@ requirejs([
     });
 
   program
+    .command('open <issue>')
+    .description('Open an issue in a browser')
+    .action(function (issue, options) {
+      auth.setConfig(function (auth) {
+        if (auth) {
+          describe.open(issue);
+        }
+      });
+    });
+
+  program
     .command('worklog <issue>')
     .description('Show worklog about an issue')
     .action(function (issue) {

--- a/lib/jira/describe.js
+++ b/lib/jira/describe.js
@@ -2,8 +2,10 @@
 define([
   'superagent',
   'cli-table',
+  'openurl',
+  'url',
   '../../lib/config'
-], function (request, Table, config) {
+], function (request, Table, openurl, url, config) {
 
   var describe = {
     query: null,
@@ -66,7 +68,7 @@ define([
             {'Status': res.body.fields.status.name},
             {'Reporter': res.body.fields.reporter.displayName
               + ' <' + res.body.fields.reporter.emailAddress + '> '},
-            {'Assignee': 
+            {'Assignee':
               (res.body.fields.assignee ? res.body.fields.assignee.displayName : "Not Assigned")
               + ' <' + (res.body.fields.assignee?res.body.fields.assignee.emailAddress:"") + '> '},
             {'Labels': res.body.fields.labels.join(', ')},
@@ -78,6 +80,10 @@ define([
 
           console.log('\r\n' + that.description + '\r\n');
         });
+    },
+
+    open: function (issue) {
+      openurl.open(url.resolve(config.auth.url, '/browse/' + issue));
     },
 
     show: function (issue, field) {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "version": "0.2.0",
   "author": "Germán Robledo <germanrcuriel@gmail.com>",
   "dependencies": {
+    "cli-table": "~0.2.0",
     "commander": "~1.1.1",
+    "openurl": "^1.1.0",
     "requirejs": "~2.1.5",
-    "superagent": "~0.13.0",
-    "cli-table": "~0.2.0"
+    "superagent": "~0.13.0"
   },
   "engines": {
     "node": ">= 0.8"


### PR DESCRIPTION
This adds a new command to open a JIRA issue in a browser:

```
# open config.auth.url + /browse/EXAMPLE-10
jira open EXAMPLE-10
```