### PR TITLE
fixed function overloading breaking transitions

### DIFF
--- a/lib/jira/describe.js
+++ b/lib/jira/describe.js
@@ -83,7 +83,7 @@ define([
     },
 
     open: function (issue) {
-      openurl.open(url.resolve(config.auth.url, '/browse/' + issue));
+      openurl.open(url.resolve(config.auth.url, 'browse/' + issue));
     },
 
     show: function (issue, field) {

--- a/lib/jira/transitions.js
+++ b/lib/jira/transitions.js
@@ -13,6 +13,11 @@ define([
     doTransition: function (issue, transitionID, resolutionID, cb) {
       var that = this;
 
+      if (typeof resolutionID === 'function') {
+        cb = resolutionID;
+        resolutionID = null;
+      }
+
       this.query = 'rest/api/2/issue/' + issue + '/transitions';
 
       var requestBody = { transition: { id: transitionID } };


### PR DESCRIPTION
Hello,

I noticed that jira start, stop and review didn't work anymore. Debugged a bit and found the culprit in a overloaded function that got the wrong parameters. 

Also fixed jira.open for jiras that are not on the root of a domain