### PR TITLE
Fixes crash displaying sprints

### DIFF
--- a/lib/jira/sprint.js
+++ b/lib/jira/sprint.js
@@ -143,6 +143,7 @@ define([
     });
 
     var pushIssues = function pushIssues(issues, table) {
+      if (!issues) return;
       issues.forEach(function(issue) {
         var priority = issue.priorityName || "Unknown",
             summary = issue.summary.length > 45 ?


### PR DESCRIPTION
Fixes the following problem:
```
mntmn@thinkstein:~% jira sprint -s 1   
****Found Rapid Board: Programmierer - Board
****Found Sprint: Dev Sprint 1 - February
/usr/lib/node_modules/jira-cmd/lib/jira/sprint.js:146
      issues.forEach(function(issue) {
            ^

TypeError: Cannot read property 'forEach' of undefined
    at pushIssues (/usr/lib/node_modules/jira-cmd/lib/jira/sprint.js:146:13)
    at displaySprintIssues (/usr/lib/node_modules/jira-cmd/lib/jira/sprint.js:160:5)
    at /usr/lib/node_modules/jira-cmd/lib/jira/sprint.js:189:11
    at /usr/lib/node_modules/jira-cmd/lib/jira/sprint.js:127:9
    at Request.callback (/usr/lib/node_modules/jira-cmd/node_modules/superagent/lib/node/index.js:586:3)
    at Request.<anonymous> (/usr/lib/node_modules/jira-cmd/node_modules/superagent/lib/node/index.js:133:10)
    at emitOne (events.js:77:13)
    at Request.emit (events.js:169:7)
    at Stream.<anonymous> (/usr/lib/node_modules/jira-cmd/node_modules/superagent/lib/node/index.js:714:12)
    at emitNone (events.js:72:20)
```