### PR TITLE
Add Windows support

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -2,13 +2,12 @@
 define([
   'commander',
   'fs',
-  '../lib/config'
+  './config'
 ], function (program, fs, config) {
 
   var Auth = {
     cfgPath: config.cfgPath || null,
-    cfgFile: config.cfgFile || null,
-    fullPath: config.cfgPath + config.cfgFile || null,
+    fullPath: config.cfgFilePath || null,
     answers: {},
 
     checkConfig: function () {
@@ -19,7 +18,7 @@ define([
         config.options = configObject.options;
 
         if (!config.options || !config.options["jira_stop"]) {
-          console.log('Ops! Seems like your ~/.jira/config.json is out of date. Please reset you configuration.');
+          console.log('Ops! Seems like your ' + this.fullPath + ' is out of date. Please reset you configuration.');
           return false;
         } else {
           return true;

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,9 +1,11 @@
-/*global requirejs,define,fs*/
-define(['fs'], function (fs) {
-  var cachePath = process.env.HOME + '/.jira/' + 'cache.json',
-      exists = fs.existsSync(cachePath),
-      cache = exists ? JSON.parse(fs.readFileSync(cachePath, 'utf-8')) : {},
-      persist = function persist() { fs.writeFileSync(cachePath, JSON.stringify(cache)); },
+/*global requirejs,fs*/
+define([
+  'fs',
+  './config'
+], function (fs, config) {
+  var exists = fs.existsSync(config.cacheFilePath),
+      cache = exists ? JSON.parse(fs.readFileSync(config.cacheFilePath, 'utf-8')) : {},
+      persist = function persist() { fs.writeFileSync(config.cacheFilePath, JSON.stringify(cache)); },
       set = function set(type, id, val) {
         cache[type] = cache[type] || {};
         cache[type][id] = {value: val, time: Date.now()};

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,13 +1,20 @@
-/*global define*/
-define(function (require) {
+/*global path*/
+define([
+  'path'
+], function (path) {
 
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
 
   return {
-    cfgPath: process.env.HOME + '/.jira/',
-    cfgFile: 'config.json',
+    cfgPath: getCfgPath(),
+	cfgFilePath: path.join(getCfgPath(), 'config.json'),
+	cacheFilePath: path.join(getCfgPath(), 'cache.json'),
     auth: {},
     options: {}
   };
 
+  function getCfgPath () {
+    var systemHomePath = process.env[(process.platform == 'win32') ? 'HOMEPATH' : 'HOME'];
+	return path.join(systemHomePath, '/.jira/');
+  }
 });


### PR DESCRIPTION
Currently this package does not seem to work on Windows, due to some path related issues. When initially running `jira` I am greeted with a file read error, with an `undefined` `process.env.HOME`.

This pull request adds a platform check in `config.js` to return `process.env.HOMEPATH` vs the
non-existent `process.env.HOME` when running on Windows. I've also replaced all path related string concatenations with `path.join()`s (which solves the cross platform forward/back slash issue in paths).