### PR TITLE
fix: allows execution on non system drive in windows

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -14,7 +14,12 @@ define([
   };
 
   function getCfgPath () {
-    var systemHomePath = process.env[(process.platform == 'win32') ? 'HOMEPATH' : 'HOME'];
+    var systemHomePath;
+    if (process.platform == 'win32') {
+      systemHomePath = process.env['HOMEDRIVE'] + process.env['HOMEPATH'];
+    } else {
+      systemHomePath = process.env['HOME'];
+    }
 	return path.join(systemHomePath, '/.jira/');
   }
 });


### PR DESCRIPTION
you cannot use the command from any drive other than c in windows.  home folder and drive are 2 separate windows env vars