### PR TITLE
Provides support to use custom jql 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ This save your credentials (base64 encoded) in your `$HOME/.jira` folder.
 
 ##### Help
 
-Usage: jira [options] [command]
+
+  Usage: jira.js [options] [command]
 
   Commands:
 
@@ -40,9 +41,11 @@ Usage: jira [options] [command]
     review <issue> [assignee] Mark issue as being reviewed [by assignee(optional)].
     done [options] <issue> Mark issue as finished.
     running                List issues in progress.
-    jql <query>            Run JQL query
+    jql [options] <query>  Run JQL query
+    link <from> <to>       link issues
     search <term>          Find issues.
     assign <issue> [user]  Assign an issue to <user>. Provide only issue# to assign to me
+    watch <issue> [user]   Watch an issue to <user>. Provide only issue# to watch to me
     comment <issue> [text] Comment an issue.
     show [options] <issue> Show info about an issue
     open <issue>           Open an issue in a browser
@@ -59,6 +62,7 @@ Usage: jira [options] [command]
 
     -h, --help     output usage information
     -V, --version  output the version number
+
 
 Each command have individual usage help (using --help or -h)
 

--- a/bin/jira.js
+++ b/bin/jira.js
@@ -106,12 +106,15 @@ requirejs([
     });
 
   program
-    .command('jql <query>')
+    .command('jql [query]')
     .description('Run JQL query')
-    .action(function (query) {
+    .option('-c, --custom <name>', 'Filter by custom jql saved in jira config', String)
+    .option('-l, --list [name]', 'list all custom jql saved in system', String)
+    .option('-a, --add <name>', 'add custom jql to be saved in jira config', String)
+    .action(function (query, options) {
       auth.setConfig(function (auth) {
         if (auth) {
-          ls.jqlSearch(query);
+          ls.jqlSearch(query, options);
         }
       });
     });

--- a/bin/jira.js
+++ b/bin/jira.js
@@ -17,8 +17,14 @@ requirejs([
   '../lib/jira/create',
   '../lib/jira/sprint',
   '../lib/jira/transitions',
-  '../lib/jira/worklog'
-], function (program, config, auth, ls, describe, assign, comment, create, sprint, transitions, worklog) {
+  '../lib/jira/worklog',
+  '../lib/jira/link',
+  '../lib/jira/watch'
+], function (program, config, auth, ls, describe, assign, comment, create, sprint, transitions, worklog, link, watch) {
+
+     function finalCb(){
+       process.exit(1);
+     }
 
   program
     .version('v0.5.4');
@@ -106,7 +112,7 @@ requirejs([
     });
 
   program
-    .command('jql [query]')
+    .command('jql <query>')
     .description('Run JQL query')
     .option('-c, --custom <name>', 'Filter by custom jql saved in jira config', String)
     .action(function (query, options) {
@@ -117,6 +123,17 @@ requirejs([
       });
     });
 
+  program
+  .command('link <from> <to>')
+  .description('link issues')
+  .action(function (from, to, options) {
+    auth.setConfig(function (auth) {
+      if (auth) {
+        link(from, to, options, finalCb);
+      }
+    });
+  });
+     
   program
     .command('search <term>')
     .description('Find issues.')
@@ -139,6 +156,21 @@ requirejs([
             assign.to(issue, user);
           } else {
             assign.me(issue);
+          }
+        }
+      });
+    });
+
+  program
+    .command('watch <issue> [user]')
+    .description('Watch an issue to <user>. Provide only issue# to watch to me')
+    .action(function (issue, user) {
+      auth.setConfig(function (auth) {
+        if (auth) {
+          if(user) {
+            watch.to(issue, user);
+          } else {
+            watch.me(issue);
           }
         }
       });

--- a/bin/jira.js
+++ b/bin/jira.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 var requirejs = require('requirejs');
-
+// https://docs.atlassian.com/jira/REST/server/?_ga=2.55654315.1871534859.1501779326-1034760119.1468908320#api/2/issueLink-linkIssues
 requirejs.config({
   baseUrl: __dirname
 });

--- a/bin/jira.js
+++ b/bin/jira.js
@@ -101,6 +101,17 @@ requirejs([
     });
 
   program
+    .command('invalid <issue>')
+    .description('Mark issue as finished.')
+    .action(function (issue) {
+      auth.setConfig(function (auth) {
+        if (auth) {
+          transitions.invalid(issue);
+        }
+      });
+    });
+
+  program
     .command('running')
     .description('List issues in progress.')
     .action(function () {
@@ -112,7 +123,7 @@ requirejs([
     });
 
   program
-    .command('jql <query>')
+    .command('jql [query]')
     .description('Run JQL query')
     .option('-c, --custom <name>', 'Filter by custom jql saved in jira config', String)
     .action(function (query, options) {

--- a/bin/jira.js
+++ b/bin/jira.js
@@ -20,8 +20,7 @@ requirejs([
   '../lib/jira/worklog',
   '../lib/jira/link',
   '../lib/jira/watch',
-  '../lib/jira/add_to_sprint'
-], function (program, config, auth, ls, describe, assign, comment, create, sprint, transitions, worklog, link, watch, add_to_sprint) {
+], function (program, config, auth, ls, describe, assign, comment, create, sprint, transitions, worklog, link, watch) {
 
      function finalCb(){
        process.exit(1);
@@ -290,16 +289,10 @@ requirejs([
                  'a single sprint board isnt found, show all matching sprint boards')
     .option('-r, --rapidboard <name>', 'Rapidboard to show sprints for', String)
     .option('-s, --sprint <name>', 'Sprint to show the issues', String)
-    .option('-a, --add <projIssue> ', 'Add project issue to sprint', String)
-    .option('-i, --sprintId <sprintId> ', 'Id of the sprint', String)
     .action(function (options) {
       auth.setConfig(function (auth) {
         if (auth) {
-          if(options.add){
-            add_to_sprint(options, finalCb);
-          } else {
             sprint(options.rapidboard, options.sprint, finalCb);
-          }
         }
       });
     });

--- a/bin/jira.js
+++ b/bin/jira.js
@@ -19,8 +19,9 @@ requirejs([
   '../lib/jira/transitions',
   '../lib/jira/worklog',
   '../lib/jira/link',
-  '../lib/jira/watch'
-], function (program, config, auth, ls, describe, assign, comment, create, sprint, transitions, worklog, link, watch) {
+  '../lib/jira/watch',
+  '../lib/jira/add_to_sprint'
+], function (program, config, auth, ls, describe, assign, comment, create, sprint, transitions, worklog, link, watch, add_to_sprint) {
 
      function finalCb(){
        process.exit(1);
@@ -289,10 +290,16 @@ requirejs([
                  'a single sprint board isnt found, show all matching sprint boards')
     .option('-r, --rapidboard <name>', 'Rapidboard to show sprints for', String)
     .option('-s, --sprint <name>', 'Sprint to show the issues', String)
+    .option('-a, --add <projIssue> ', 'Add project issue to sprint', String)
+    .option('-i, --sprintId <sprintId> ', 'Id of the sprint', String)
     .action(function (options) {
       auth.setConfig(function (auth) {
         if (auth) {
-          sprint(options.rapidboard, options.sprint);
+          if(options.add){
+            add_to_sprint(options, finalCb);
+          } else {
+            sprint(options.rapidboard, options.sprint, finalCb);
+          }
         }
       });
     });

--- a/bin/jira.js
+++ b/bin/jira.js
@@ -109,8 +109,6 @@ requirejs([
     .command('jql [query]')
     .description('Run JQL query')
     .option('-c, --custom <name>', 'Filter by custom jql saved in jira config', String)
-    .option('-l, --list [name]', 'list all custom jql saved in system', String)
-    .option('-a, --add <name>', 'add custom jql to be saved in jira config', String)
     .action(function (query, options) {
       auth.setConfig(function (auth) {
         if (auth) {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -16,7 +16,7 @@ define([
 
         config.auth = configObject.auth;
         config.options = configObject.options;
-
+        config.custom_jql = configObject.custom_jql;
         if (!config.options || !config.options["jira_stop"]) {
           console.log('Ops! Seems like your ' + this.fullPath + ' is out of date. Please reset you configuration.');
           return false;
@@ -123,6 +123,9 @@ define([
 
       configFile = {
         auth: auth,
+        custom_jql:{
+          reported: "reporter=currentUser()"
+        },
         options: {
           jira_stop: {
             status: "To Do"
@@ -134,7 +137,8 @@ define([
             status: "In Review"
           },
           jira_done: {
-            status: "Done"
+            status: "Done",
+            check_resolution: false
           },
           available_issues_statuses: [
             "Open",

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -124,7 +124,7 @@ define([
       configFile = {
         auth: auth,
         custom_jql:{
-          reported: "reporter=currentUser()"
+          reported: "reporter=currentUser() and status not in ('Done')"
         },
         options: {
           jira_stop: {

--- a/lib/jira/create.js
+++ b/lib/jira/create.js
@@ -258,7 +258,6 @@ define([
 
     saveIssue: function () {
       this.query = 'rest/api/2/issue';
-      
       request
         .post(config.auth.url + this.query)
         .send(this.answers)

--- a/lib/jira/create.js
+++ b/lib/jira/create.js
@@ -2,8 +2,9 @@
 define([
   'commander',
   'superagent',
-  '../../lib/config'
-], function (program, request, config) {
+  '../../lib/config',
+  '../../lib/cache'
+], function (program, request, config, cache) {
 
   var create = {
     query: null,
@@ -115,7 +116,7 @@ define([
       }, false, issuePriorities);
     },
 
-    newIssue: function () {
+    newIssue: function (projIssue) {
       var that = this;
 
       var project = typeof(projIssue) === 'string' ? projIssue : undefined;
@@ -226,7 +227,10 @@ define([
 
     getMeta: function (callback) {
       this.query = 'rest/api/2/issue/createmeta';
-
+      var cachedRes = cache.getSync('meta', 'project', 1000*60*60*24*7);
+      if(cachedRes){
+        return callback(cachedRes);
+      }
       request
         .get(config.auth.url + this.query)
         .set('Content-Type', 'application/json')
@@ -235,14 +239,18 @@ define([
           if (!res.ok) {
             return console.log((res.body.errorMessages || [res.error]).join('\n'));
           }
-
+          cache.set('meta', 'project', res.body.projects);       
           callback(res.body.projects);
         });
     },
 
     getPriorities: function (callback) {
       this.query = 'rest/api/2/priority';
-
+      var cachedRes = cache.getSync('meta', 'priorities', 1000*60*60*24*7);
+      if(cachedRes){
+        return callback(cachedRes);
+      }
+      
       request
         .get(config.auth.url + this.query)
         .set('Content-Type', 'application/json')
@@ -251,7 +259,7 @@ define([
           if (!res.ok) {
             return console.log(res.body.errorMessages.join('\n'));
           }
-
+          cache.set('meta', 'priorities', res.body);       
           callback(res.body);
         });
     },

--- a/lib/jira/create.js
+++ b/lib/jira/create.js
@@ -258,10 +258,10 @@ define([
 
     saveIssue: function () {
       this.query = 'rest/api/2/issue';
-
+      
       request
         .post(config.auth.url + this.query)
-        .send(JSON.stringify(this.answers))
+        .send(this.answers)
         .set('Content-Type', 'application/json')
         .set('Authorization', 'Basic ' + config.auth.token)
         .end(function (res) {

--- a/lib/jira/describe.js
+++ b/lib/jira/describe.js
@@ -14,7 +14,6 @@ define([
 
     getIssueField: function (field) {
       var that = this;
-
       request
         .get(config.auth.url + this.query + '?fields=' + field)
         .set('Content-Type', 'application/json')
@@ -38,7 +37,6 @@ define([
 
     getIssue: function () {
       var that = this;
-
       request
         .get(config.auth.url + this.query)
         .set('Content-Type', 'application/json')

--- a/lib/jira/describe.js
+++ b/lib/jira/describe.js
@@ -14,6 +14,7 @@ define([
 
     getIssueField: function (field) {
       var that = this;
+
       request
         .get(config.auth.url + this.query + '?fields=' + field)
         .set('Content-Type', 'application/json')
@@ -37,6 +38,7 @@ define([
 
     getIssue: function () {
       var that = this;
+
       request
         .get(config.auth.url + this.query)
         .set('Content-Type', 'application/json')

--- a/lib/jira/link.js
+++ b/lib/jira/link.js
@@ -1,0 +1,111 @@
+/*global requirejs,console,define,fs*/
+define([
+  'commander',
+  'superagent',
+  '../../lib/config',
+  '../../lib/cache'
+], function (program, request, config, cache) {
+     function ask(question, callback, yesno, values, options) {
+       var that = this,
+           options = options || {},
+           issueTypes = [],
+           i = 0;
+
+       if (values && values.length > 0) {
+         for (i; i < values.length; i++) {
+           if (that.isSubTask) {
+             if (values[i].subtask !== undefined) {
+               if (values[i].subtask) {
+                 issueTypes.push('(' + values[i].id + ') ' + options.from + ' ' + values[i].outward + ' '+ options.to);
+               }
+             } else {
+               issueTypes.push('(' + values[i].id + ') ' + options.from + ' ' + values[i].outward + ' '+ options.to);
+             }
+           } else {
+             if (!values[i].subtask) {
+               issueTypes.push('(' + values[i].id + ') ' +options.from + ' ' + values[i].outward + ' '+ options.to);
+             }
+           }
+         }
+         console.log(issueTypes.join('\n'));
+       }
+
+       program.prompt(question, function (answer) {
+         if (answer.length > 0) {
+           callback(answer);
+         } else {
+           if (yesno) {
+             callback(false);
+           } else {
+             that.ask(question, callback);
+           }
+         }
+       }, options);
+     }
+
+     function askLinkType(options, cb){
+       getLinkType(function(linkTypes){
+         ask('Select the linktype: ', function (link) {
+           cb(link);
+         }, false, linkTypes, options);
+       });
+     }
+     
+     function getLinkType(cb){
+       this.query = '/rest/api/2/issueLinkType';
+       var cachedRes = cache.getSync('meta', 'linktype', 1000*60*60*24*7*30);
+       if(cachedRes){
+         return cb(cachedRes);
+       }
+       request
+       .get(config.auth.url + this.query)
+       .set('Content-Type', 'application/json')
+       .set('Authorization', 'Basic ' + config.auth.token)
+       .end(function (res) {
+         if (!res.ok) {
+           return console.log(res.body.errorMessages.join('\n'));
+         }
+         cache.set('meta', 'linktype', res.body.issueLinkTypes);
+         return console.log(res.body.issueLinkTypes);
+       });
+     }
+
+     function callLink(reqOpts, cb){
+       this.query = '/rest/api/2/issueLink';
+       request
+       .post(config.auth.url + this.query)
+       .send(reqOpts)
+       .set('Content-Type', 'application/json')
+       .set('Authorization', 'Basic ' + config.auth.token)
+       .end(function (res) {
+         if (!res.ok) {
+           return console.log(res.body.errorMessages.join('\n'));
+         }
+         console.log('Issues linked');
+         return cb();
+       });
+     }
+
+     return function link(from, to, options, cb){
+       var reqOpts = {
+         "type": {
+           "name": "Relate"
+         },
+         "inwardIssue": {
+           "key": from
+         },
+         "outwardIssue": {
+           "key": to
+         },
+         "comment": {
+           "body": "Linked related issue!"
+         }
+       }
+       options.from = from;
+       options.to = to;
+       askLinkType(options, function(linkname){
+         reqOpts.type.id = linkname;
+         callLink(reqOpts, cb);
+       });
+     } 
+});

--- a/lib/jira/ls.js
+++ b/lib/jira/ls.js
@@ -106,7 +106,7 @@ define([
       }
       return this.getIssues();
     },
-    getAvailableStatuses: function () {      
+    getAvailableStatuses: function () {
       return config.options.available_issues_statuses.join('", "');
     }
   };

--- a/lib/jira/ls.js
+++ b/lib/jira/ls.js
@@ -15,7 +15,6 @@ define([
     getIssues: function () {
       var that = this,
         i = 0;
-
       request
         .get(config.auth.url + this.query)
         .set('Content-Type', 'application/json')
@@ -99,11 +98,15 @@ define([
       return this.getIssues();
     },
 
-    jqlSearch: function (jql) {
-      this.query = 'rest/api/2/search?jql=' + encodeURIComponent(jql);
+    jqlSearch: function (jql, options) {
+      if(options.custom && config.custom_jql && config.custom_jql[options.custom]){
+        this.query = 'rest/api/2/search?jql=' + encodeURIComponent(config.custom_jql[options.custom]);        
+      } else{
+        this.query = 'rest/api/2/search?jql=' + encodeURIComponent(jql);
+      }
       return this.getIssues();
     },
-    getAvailableStatuses: function () {
+    getAvailableStatuses: function () {      
       return config.options.available_issues_statuses.join('", "');
     }
   };

--- a/lib/jira/sprint.js
+++ b/lib/jira/sprint.js
@@ -63,7 +63,6 @@ define([
     if (typeof(sprintID) !== 'string') {
       sprintID = undefined;
     }
-
     request
       .get(config.auth.url + 'rest/greenhopper/latest/sprintquery/' + rapidBoardID)
       .set('Content-Type', 'application/json')

--- a/lib/jira/sprint.js
+++ b/lib/jira/sprint.js
@@ -3,27 +3,33 @@ define([
   'commander',
   'superagent',
   'cli-table',
-  '../../lib/config'
-], function (program, request, Table, config) {
-
-  var getRapidBoardID = function getRapidBoardID(rapidBoardID, cb){
-    if (typeof(rapidBoardID) !== 'string') {
-      rapidBoardID = undefined;
-    }
-
-    request
-      .get(config.auth.url + 'rest/greenhopper/latest/rapidviews/list')
-      .set('Content-Type', 'application/json')
-      .set('Authorization', 'Basic ' + config.auth.token)
-      .end(function (res) {
-        if (!res.ok) {
-          console.log("Error getting rapid boards. HTTP Status Code: " + res.status);
-          console.dir(res.body);
-          return
-        }
-        displayRapidBoards(rapidBoardID, res.body, cb);
-      });
-  }
+  '../../lib/config',
+  '../../lib/cache'
+], function (program, request, Table, config, cache) {
+      
+     var getRapidBoardID = function getRapidBoardID(rapidBoardID, cb){
+       if (typeof(rapidBoardID) !== 'string') {
+         rapidBoardID = undefined;
+       }
+       var cachedRes = cache.getSync('sprint', 'rapid', 1000*60*60*24);
+       if(cachedRes){
+         displayRapidBoards(rapidBoardID, cachedRes, cb);
+       }
+       request
+       .get(config.auth.url + 'rest/greenhopper/latest/rapidviews/list')
+       .set('Content-Type', 'application/json')
+       .set('Authorization', 'Basic ' + config.auth.token)
+       .end(function (res) {
+         if (!res.ok) {
+           console.log("Error getting rapid boards. HTTP Status Code: " + res.status);
+           return
+         }
+         cache.set('sprint', 'rapid', res.body);
+         if(!cachedRes){
+           displayRapidBoards(rapidBoardID, res.body, cb);
+         }
+       });
+     }
 
   var displayRapidBoards = function displayRapidBoards(rapidBoardID, data, cb) {
     var table = new Table({head: ['Key', 'Name']});
@@ -70,7 +76,6 @@ define([
       .end(function (res) {
         if (!res.ok) {
           console.log("Error getting sprints. HTTP Status Code: " + res.status);
-          console.dir(res.body);
           return
         }
         displaySprints(rapidBoardID, sprintID, res.body, cb);
@@ -111,8 +116,7 @@ define([
       console.log("\nMatching Sprints:");
       console.log("=========================================\n")
       console.log(table.toString());
-      debugger
-      return cb(pushTable[pushTable.length-1][0]); //picks the last sprint
+      return cb(pushTable[pushTable.length-1][0], pushTable); //picks the last sprint
     }
   }
 
@@ -190,11 +194,17 @@ define([
     displayTable("Incompleted Issues:", incompleted);
   }
 
-  return function sprint(userRapidBoardID, userSprintID) {
+  return function sprint(userRapidBoardID, userSprintID, cb) {
     getRapidBoardID(userRapidBoardID, function(rapidBoardID) {
-      getSprintID(rapidBoardID, userSprintID, function(sprintID) {
+      getSprintID(rapidBoardID, userSprintID, function(sprintID, allSprints) {
         getSprintIssues(rapidBoardID, sprintID, function(data) {
-          displaySprintIssues(rapidBoardID, sprintID, data);
+          if(cb){
+            displaySprintIssues(rapidBoardID, sprintID, data);
+            return cb(allSprints);
+          }
+          else{
+            displaySprintIssues(rapidBoardID, sprintID, data);
+          }
         });
       });
     });

--- a/lib/jira/sprint.js
+++ b/lib/jira/sprint.js
@@ -63,6 +63,7 @@ define([
     if (typeof(sprintID) !== 'string') {
       sprintID = undefined;
     }
+
     request
       .get(config.auth.url + 'rest/greenhopper/latest/sprintquery/' + rapidBoardID)
       .set('Content-Type', 'application/json')

--- a/lib/jira/sprint.js
+++ b/lib/jira/sprint.js
@@ -63,9 +63,8 @@ define([
     if (typeof(sprintID) !== 'string') {
       sprintID = undefined;
     }
-
     request
-      .get(config.auth.url + 'rest/greenhopper/latest/sprintquery/' + rapidBoardID)
+      .get(config.auth.url + 'rest/greenhopper/latest/sprintquery/' + rapidBoardID)    
       .set('Content-Type', 'application/json')
       .set('Authorization', 'Basic ' + config.auth.token)
       .end(function (res) {
@@ -88,6 +87,9 @@ define([
           pushTable = [[item.id, item.name, item.state]]
           break
         }
+        if(item.state !== 'ACTIVE'){
+          continue;
+        }
         if (item.name.toLowerCase().indexOf(sprintID.toLowerCase()) === -1) {
           continue
         }
@@ -109,11 +111,16 @@ define([
       console.log("\nMatching Sprints:");
       console.log("=========================================\n")
       console.log(table.toString());
+      debugger
+      return cb(pushTable[pushTable.length-1][0]); //picks the last sprint
     }
   }
 
   var getSprintIssues = function getSprintIssues(rapidBoardID, sprintID, cb) {
-    var qParams = 'rapidViewId=' + rapidBoardID + '&sprintId=' + sprintID
+    var qParams = 'rapidViewId=' + rapidBoardID
+    if(sprintID){
+       qParams +='&sprintId=' + sprintID;
+    }
     request
       .get(config.auth.url + 'rest/greenhopper/latest/rapid/charts/sprintreport?' + qParams)
       .set('Content-Type', 'application/json')

--- a/lib/jira/transitions.js
+++ b/lib/jira/transitions.js
@@ -182,7 +182,23 @@ define([
           });
         });
       });
+    },
+
+    invalid: function (issue, resolution) {
+      var that = this;
+
+      this.transitionName = config.options["jira_invalid"]["status"];
+      this.resolutionName = resolution;
+
+      this.getResolutionCode(this.resolutionName, function (resolutionID) {
+        that.getTransitionCode(issue, that.transitionName, function (transitionID) {
+          that.doTransition(issue, transitionID, resolutionID, function () {
+            return console.log('Issue [' + issue + '] moved to ' + that.transitionName);
+          });
+        });
+      });
     }
+
 
   };
 

--- a/lib/jira/transitions.js
+++ b/lib/jira/transitions.js
@@ -21,7 +21,7 @@ define([
       this.query = 'rest/api/2/issue/' + issue + '/transitions';
 
       var requestBody = { transition: { id: transitionID } };
-      if (resolutionID) {
+      if (resolutionID  && config.options["jira_done"]["check_resolution"]) {
         requestBody.fields = {resolution: {id: resolutionID}};
       }
 
@@ -46,7 +46,6 @@ define([
         i = 0;
 
       this.query = 'rest/api/2/issue/' + issue + '/transitions';
-
       request
         .get(config.auth.url + this.query)
         .set('Content-Type', 'application/json')
@@ -92,7 +91,6 @@ define([
         i = 0;
 
       this.query = 'rest/api/2/resolution';
-
       request
         .get(config.auth.url + this.query)
         .set('Content-Type', 'application/json')

--- a/lib/jira/watch.js
+++ b/lib/jira/watch.js
@@ -1,0 +1,36 @@
+/*global requirejs,console,define,fs*/
+define([
+  'superagent',
+  '../../lib/config'
+], function (request, config) {
+
+  var assign = {
+    query: null,
+    table: null,
+
+    to: function (ticket, assignee) {
+      this.query = 'rest/api/2/issue/' + ticket + '/watchers';
+
+      request
+        .post(config.auth.url + this.query)
+        .send('"'+assignee+'"')
+        .set('Content-Type', 'application/json')
+        .set('Authorization', 'Basic ' + config.auth.token)
+        .end(function (res) {
+          if (!res.ok) {
+            return console.log((res.body.errorMessages || [res.error]).join('\n'));
+          }
+
+          return console.log('Added '+assignee+' as watcher to [' + ticket + '] ' + '.');
+
+        });
+    },
+    me: function (ticket) {
+      this.to(ticket, config.auth.user);
+    }
+
+  };
+
+  return assign;
+
+});


### PR DESCRIPTION
Currently we can only run custom jql from commandline with no support to save and run it anytime. With this PR we can now save this jql in config.json and use it by calling "jira jql -c keyname" where keyname is the keyname we've used to store our jql against in config.json.