### PR TITLE
Fix undefined join if labels are empty

### DIFF
--- a/lib/jira/describe.js
+++ b/lib/jira/describe.js
@@ -71,7 +71,7 @@ define([
             {'Assignee':
               (res.body.fields.assignee ? res.body.fields.assignee.displayName : "Not Assigned")
               + ' <' + (res.body.fields.assignee?res.body.fields.assignee.emailAddress:"") + '> '},
-            {'Labels': res.body.fields.labels.join(', ')},
+            {'Labels': (res.body.fields.labels ? res.body.fields.labels.join(', '): "")},
             {'Subtasks': res.body.fields.subtasks.length},
             {'Comments': res.body.fields.comment.total}
           );


### PR DESCRIPTION
Fix "TypeError: Cannot read property 'join' of undefined" if Labels are empty