### PR TITLE
Upgrade cli-table2 for jira cmd

### DIFF
--- a/lib/jira/comment.js
+++ b/lib/jira/comment.js
@@ -1,7 +1,7 @@
 /*global requirejs,console,define,fs*/
 define([
   'superagent',
-  'cli-table',
+  'cli-table2',
   '../../lib/config'
 ], function (request, Table, config) {
 

--- a/lib/jira/describe.js
+++ b/lib/jira/describe.js
@@ -1,7 +1,7 @@
 /*global requirejs,console,define,fs*/
 define([
   'superagent',
-  'cli-table',
+  'cli-table2',
   'openurl',
   'url',
   '../../lib/config'

--- a/lib/jira/ls.js
+++ b/lib/jira/ls.js
@@ -1,7 +1,7 @@
 /*global requirejs,define,fs*/
 define([
   'superagent',
-  'cli-table',
+  'cli-table2',
   '../../lib/config'
 ], function (request, Table, config) {
 

--- a/lib/jira/sprint.js
+++ b/lib/jira/sprint.js
@@ -2,7 +2,7 @@
 define([
   'commander',
   'superagent',
-  'cli-table',
+  'cli-table2',
   '../../lib/config',
   '../../lib/cache'
 ], function (program, request, Table, config, cache) {

--- a/lib/jira/transitions.js
+++ b/lib/jira/transitions.js
@@ -1,7 +1,7 @@
 /*global requirejs,console,define,fs*/
 define([
   'superagent',
-  'cli-table',
+  'cli-table2',
   '../../lib/config'
 ], function (request, Table, config) {
 

--- a/lib/jira/worklog.js
+++ b/lib/jira/worklog.js
@@ -2,7 +2,7 @@
 define([
   'commander',
   'superagent',
-  'cli-table',
+  'cli-table2',
   'moment',
   '../../lib/config'
 ], function (program, request, Table, moment, config) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "async": "^2.6.0",
-    "cli-table": "~0.2.0",
+    "cli-table2": "^0.2.0",
     "commander": "~1.1.1",
     "dargs": "^5.1.0",
     "moment": "~> 2.19.3",


### PR DESCRIPTION
I got a bug when showing jira tickets with `cli-table` in my database. It works just fine with `cli-table2`