### PR TITLE
Enhanced new issue creation functionality

### DIFF
--- a/bin/jira.js
+++ b/bin/jira.js
@@ -22,9 +22,8 @@ requirejs([
     '../lib/jira/worklog',
     '../lib/jira/link',
     '../lib/jira/watch',
-    '../lib/jira/add_to_sprint',
     '../lib/jira/new'
-], function (program, config, auth, ls, describe, assign, comment, create, sprint, transitions, worklog, link, watch, add_to_sprint, new_create) {
+], function (program, config, auth, ls, describe, assign, comment, create, sprint, transitions, worklog, link, watch, new_create) {
 
      function finalCb(){
        process.exit(1);

--- a/bin/jira.js
+++ b/bin/jira.js
@@ -9,20 +9,22 @@ requirejs.config({
 });
 
 requirejs([
-  'commander',
-  '../lib/config',
-  '../lib/auth',
-  '../lib/jira/ls',
-  '../lib/jira/describe',
-  '../lib/jira/assign',
-  '../lib/jira/comment',
-  '../lib/jira/create',
-  '../lib/jira/sprint',
-  '../lib/jira/transitions',
-  '../lib/jira/worklog',
-  '../lib/jira/link',
-  '../lib/jira/watch',
-], function (program, config, auth, ls, describe, assign, comment, create, sprint, transitions, worklog, link, watch) {
+    'commander',
+    '../lib/config',
+    '../lib/auth',
+    '../lib/jira/ls',
+    '../lib/jira/describe',
+    '../lib/jira/assign',
+    '../lib/jira/comment',
+    '../lib/jira/create',
+    '../lib/jira/sprint',
+    '../lib/jira/transitions',
+    '../lib/jira/worklog',
+    '../lib/jira/link',
+    '../lib/jira/watch',
+    '../lib/jira/add_to_sprint',
+    '../lib/jira/new'
+], function (program, config, auth, ls, describe, assign, comment, create, sprint, transitions, worklog, link, watch, add_to_sprint, new_create) {
 
      function finalCb(){
        process.exit(1);
@@ -273,24 +275,44 @@ requirejs([
       });
     });
 
-  program
-    .command('config')
-    .description('Change configuration')
-    .option('-c, --clear', 'Clear stored configuration')
-    .action(function (options) {
-      if (options.clear) {
-        auth.clearConfig();
-      } else {
-        auth.setConfig();
-      }
-    }).on('--help', function () {
-      console.log('  Config Help:');
-      console.log();
-      console.log('    Jira URL: https://foo.atlassian.net/');
-      console.log('    Username: user (for user@foo.bar)');
-      console.log('    Password: Your password');
-      console.log();
-    });
+
+    program
+        .command('new [key]')
+        .description('Create an issue or a sub-task')
+        .option('-p, --project <project>', 'Rapid board on which project is to be created', String)
+        .option('-P, --priority <priority>', 'priority of the issue', String)
+        .option('-T --type <type>', 'Issue type', String)
+        .option('-s --subtask <subtask>', 'Issue subtask', String)
+        .option('-t --title <title>', 'Issue title', String)
+        .option('-d --description <description>', 'Issue description', String)
+        .option('-a --assignee <assignee>', 'Issue assignee', String)
+        .action(function (key, options) {      
+            auth.setConfig(function (auth) {
+                if (auth) {
+                  options.key=key;
+                  new_create.create(options, finalCb);
+                }
+            });
+        });
+
+    program
+        .command('config')
+        .description('Change configuration')
+        .option('-c, --clear', 'Clear stored configuration')
+        .action(function (options) {
+            if (options.clear) {
+                auth.clearConfig();
+            } else {
+                auth.setConfig();
+            }
+        }).on('--help', function () {
+            console.log('  Config Help:');
+            console.log();
+            console.log('    Jira URL: https://foo.atlassian.net/');
+            console.log('    Username: user (for user@foo.bar)');
+            console.log('    Password: Your password');
+            console.log();
+        });
 
   program
     .command('sprint')

--- a/bin/jira.js
+++ b/bin/jira.js
@@ -2,6 +2,8 @@
 
 var requirejs = require('requirejs');
 // https://docs.atlassian.com/jira/REST/server/?_ga=2.55654315.1871534859.1501779326-1034760119.1468908320#api/2/issueLink-linkIssues
+// https://developer.atlassian.com/jiradev/jira-apis/about-the-jira-rest-apis/jira-rest-api-tutorials/jira-rest-api-examples#JIRARESTAPIexamples-Creatinganissueusingcustomfields
+// required fields https://jira.mypaytm.com/rest/api/2/issue/createmeta?projectKeys=MDO&expand=projects.issuetypes.fields&
 requirejs.config({
   baseUrl: __dirname
 });

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -128,6 +128,33 @@ define([
         custom_jql:{
           reported: "reporter=currentUser() and status not in ('Done')"
         },
+        "default_create" : {
+	  "__always_ask" :{
+	    "fields" :{
+	      "description" :{},
+	      "priority": {}
+	    }
+	  },
+          "YOUR_ALIAS" :{
+	    "project": "YOUR_PROJECT",
+	    "issueType": 3,
+	    "default" : {
+	      "components": [{
+		"id": "15226"
+	      }],
+	      "customfield_12901" : "infrastructure",
+	      "customfield_12902": {
+		"id": "11237"
+	      }
+	    }            
+          }
+        },
+        "edit_meta": {
+          "sprint": {
+	      "name":"customfield_10007",
+	      "type":"number"
+	  }
+        },
         options: {
           jira_stop: {
             status: "To Do"

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -17,6 +17,8 @@ define([
         config.auth = configObject.auth;
         config.options = configObject.options;
         config.custom_jql = configObject.custom_jql;
+        config.edit_meta = configObject.edit_meta;
+        config.default_create = configObject.default_create;
         if (!config.options || !config.options["jira_stop"]) {
           console.log('Ops! Seems like your ' + this.fullPath + ' is out of date. Please reset you configuration.');
           return false;

--- a/lib/jira/new.js
+++ b/lib/jira/new.js
@@ -12,6 +12,7 @@ define([
     table: null,
     isSubTask: false,
     projects: [],
+    projectMeta:{},
     priorities: [],
     answers: {
       fields: {}
@@ -22,23 +23,22 @@ define([
         options = options || {},
         issueTypes = [],
         i = 0;
-
       if(answer || answer===false){
         return callback(answer);
-      }      
+      }
       if (values && values.length > 0) {
         for (i; i < values.length; i++) {
           if (that.isSubTask) {
             if (values[i].subtask !== undefined) {
               if (values[i].subtask) {
-                issueTypes.push('(' + values[i].id + ') ' + values[i].name);
+                issueTypes.push('(' + values[i].id + ') ' + (values[i].name?values[i].name :values[i].value));
               }
             } else {
-              issueTypes.push('(' + values[i].id + ') ' + values[i].name);
+              issueTypes.push('(' + values[i].id + ') ' + (values[i].name?values[i].name :values[i].value));
             }
           } else {
             if (!values[i].subtask) {
-              issueTypes.push('(' + values[i].id + ') ' + values[i].name);
+              issueTypes.push('(' + values[i].id + ') ' + (values[i].name?values[i].name :values[i].value));
             }
           }
         }
@@ -57,7 +57,112 @@ define([
       }, options);
     },
 
-    create: function(options, cb){
+    askProject: function (project, callback) {
+      var that = this,
+        i = 0;
+      this.ask('Type the project name or key: ', function (answer) {
+        var projectId = 0,
+          index = 0;
+        answer = answer.charAt(0).toUpperCase() + answer.substring(1).toLowerCase();
+        for (i; i < that.projects.length; i++) {
+          if (answer == that.projects[i].key ||answer.toUpperCase() == that.projects[i].key) {
+            projectId = that.projects[i].id;
+            index = i;
+          } else if (answer == that.projects[i].name) {
+            projectId = that.projects[i].id;
+            index = i;
+          }
+        }
+        if (projectId > 0) {
+          callback(projectId, index, answer.toUpperCase());
+        } else {
+          console.log('Project "' + answer + '" does not exists.');
+          that.askProject(project, callback);
+        }
+      }, false, null, project);
+    },
+
+    getMeta: function (key, callback) {
+      this.query = 'rest/api/2/issue/createmeta';
+      if(key){
+        this.query += '?projectKeys='+key+'&expand=projects.issuetypes.fields';
+      }
+      var cachedRes = cache.getSync('meta', key?'project'+key:'project', 1000*60*60*24*7);
+      if(cachedRes){
+        return callback(null, cachedRes);
+      }
+      request
+        .get(config.auth.url + this.query)
+        .set('Content-Type', 'application/json')
+        .set('Authorization', 'Basic ' + config.auth.token)
+        .end(function (res) {
+          if (!res.ok) {
+            console.log((res.body.errorMessages || [res.error]).join('\n'));
+            return callback((res.body.errorMessages || [res.error]).join('\n'));
+          }
+          cache.set('meta', key?'project'+key:'project', res.body.projects);       
+          callback(null, res.body.projects);
+        });
+    },
+
+    askIssueType: function (type, callback) {
+      var that = this,
+        issueTypeArray = create.projectMeta.issuetypes;
+      that.ask('Select issue type: ', function (issueType) {
+        callback(issueType);
+      }, false, issueTypeArray, type);
+    },
+
+    askRequired: function(eachField, eachFieldKey, defaultAnswer, scb){
+      var that =  this;
+      if(!eachField.required && !(config.default_create && config.default_create['__always_ask'] && config.default_create['__always_ask'].fields && config.default_create['__always_ask'].fields[eachFieldKey])){
+        return scb();
+      }
+      var question = (eachField.allowedValues? 'Select ' : 'Enter ') +eachField.name+' : ';
+      that.ask(question,function(answer){
+        if(answer){
+          //supplying answer by field type
+           if(eachField.schema.type == 'array'){
+             if(eachField.schema.items !=='string'){
+               create.answers.fields[eachFieldKey] = [{
+                 id: answer
+               }];
+             } else {
+               answer =  answer.split(',');             
+               create.answers.fields[eachFieldKey] = answer;
+             }
+           } else if (eachField.schema.type == 'string') {
+             create.answers.fields[eachFieldKey] = answer;
+           } else {
+             create.answers.fields[eachFieldKey] = {
+               id : answer
+             }
+           }
+          return scb();
+        } else {
+          return create.askRequired(eachField, eachFieldKey, defaultAnswer, scb);
+        }
+      }, false, eachField.allowedValues, defaultAnswer);
+    },
+
+    saveIssue: function (cb) {
+      this.query = 'rest/api/2/issue';
+      request
+        .post(config.auth.url + this.query)
+        .send(create.answers)
+        .set('Content-Type', 'application/json')
+        .set('Authorization', 'Basic ' + config.auth.token)
+        .end(function (res) {
+          if (!res.ok) {
+            console.log(res.body.errorMessages.join('\n'));
+            return cb(res.body.errorMessages.join('\n'));
+          }
+        console.log('Issue ' + res.body.key + ' created successfully!');
+          return cb();
+        });
+    },
+          
+    create: function(options, cb){      
       // get project 
       // verify the project
       // call meta for this project https://jira.mypaytm.com/rest/api/2/issue/createmeta?projectKeys=MDO&expand=projects.issuetypes.fields&
@@ -67,12 +172,100 @@ define([
       // if given then set the default values from config.json for payoutmdo
       // prompt the input for other required:true fields
       // 
-      // async.waterfall([
-      //   async.constant.bind(null,options),
-      //   function(options, wcb){
-          
-      //   }
-      // ])
+      var that =  this;
+      async.waterfall([
+        function(wcb){
+          create.getMeta(null, function (err ,meta) {            
+            if(err){
+              return wcb(err);
+            }
+            create.projects=meta;
+            return wcb(null, options);
+          });                  
+        },        
+        function(options,wcb){          
+          if(options.key && config.default_create && config.default_create[options.key] && config.default_create[options.key].project){
+              if(!options.project && config.default_create[options.key].project){
+                options.project = config.default_create[options.key].project;
+              }
+          }
+          create.askProject(options.project, function(projectId, index, projectKey){
+            options.projectId=projectId;
+            options.projectIndex = index;
+            options.project = projectKey;            
+            create.answers.fields.project = {
+              id: projectId
+            };
+            return  wcb(null, options);
+          });
+        },
+        function (options, wcb){
+          create.getMeta(options.project, function (err ,meta) {            
+            if(err){
+              return wcb(err);
+            }
+            meta.forEach(function(eachProjectMeta){
+              if(eachProjectMeta.id==options.projectId){
+                create.projectMeta = eachProjectMeta;
+              }
+            });
+            if(!create.projectMeta){
+              return wcb('project meta not found');
+            }
+            return wcb(null, options);
+          });                            
+        },
+        function(options, wcb){
+          //using default from config
+          if(options.key && config.default_create && config.default_create[options.key] && config.default_create[options.key].issueType){
+              if(!options.type && config.default_create[options.key].issueType){
+                options.type = config.default_create[options.key].issueType;
+              }
+          }
+          create.askIssueType(options.type, function(issueType){
+            create.answers.fields.issuetype = {
+              id: issueType
+            };
+            options.type= issueType;
+            create.projectMeta.issuetypes.forEach(function(eachIssueType){
+              if(eachIssueType.id==issueType){
+                create.issueType=eachIssueType;
+              }
+            });
+            if(!create.issueType){
+              return wcb(new Error('invalid issue type'));
+            }
+            return wcb(null, options);
+          });
+        },
+        function(options, wcb){
+          //ask for required fields
+          async.eachSeries(Object.keys(create.issueType.fields), function (eachFieldKey, scb){
+            var eachField = create.issueType.fields[eachFieldKey];
+            //if only 1 allowed value then take it as answer  and dont prompt the user
+            var defaultAnswer;
+            if(eachField.allowedValues && eachField.allowedValues.length==1){
+              defaultAnswer = eachField.allowedValues[0].id;
+              return scb();
+            }
+            //picking field config from config
+            if(options.key && config.default_create && config.default_create[options.key] && config.default_create[options.key].default){
+              if(config.default_create[options.key].default[eachFieldKey]){
+                create.answers.fields[eachFieldKey] = config.default_create[options.key].default[eachFieldKey];
+                return scb();
+              }
+            }
+            return create.askRequired(eachField, eachFieldKey, defaultAnswer, scb);
+          }, function(){
+               return wcb(null, options);
+             });
+        },
+        function (options, wcb){
+          create.saveIssue(wcb);
+        }
+      ],function(err){
+          return cb();
+        });
     }
   };
 

--- a/lib/jira/new.js
+++ b/lib/jira/new.js
@@ -1,0 +1,81 @@
+/*global requirejs,console,define,fs*/
+define([
+  'commander',
+  'superagent',
+  '../../lib/config',
+  '../../lib/cache',
+  'async'
+], function (program, request, config, cache, async) {
+
+  var create = {
+    query: null,
+    table: null,
+    isSubTask: false,
+    projects: [],
+    priorities: [],
+    answers: {
+      fields: {}
+    },
+
+    ask: function (question, callback, yesno, values, answer) {
+      var that = this,
+        options = options || {},
+        issueTypes = [],
+        i = 0;
+
+      if(answer || answer===false){
+        return callback(answer);
+      }      
+      if (values && values.length > 0) {
+        for (i; i < values.length; i++) {
+          if (that.isSubTask) {
+            if (values[i].subtask !== undefined) {
+              if (values[i].subtask) {
+                issueTypes.push('(' + values[i].id + ') ' + values[i].name);
+              }
+            } else {
+              issueTypes.push('(' + values[i].id + ') ' + values[i].name);
+            }
+          } else {
+            if (!values[i].subtask) {
+              issueTypes.push('(' + values[i].id + ') ' + values[i].name);
+            }
+          }
+        }
+        console.log(issueTypes.join('\n'));
+      }
+      program.prompt(question, function (answer) {
+        if (answer.length > 0) {
+          callback(answer);
+        } else {
+          if (yesno) {
+            callback(false);
+          } else {
+            that.ask(question, callback);
+          }
+        }
+      }, options);
+    },
+
+    create: function(options, cb){
+      // get project 
+      // verify the project
+      // call meta for this project https://jira.mypaytm.com/rest/api/2/issue/createmeta?projectKeys=MDO&expand=projects.issuetypes.fields&
+      // get issueType
+      // get required:true fields from meta
+      // check if input config key given eg. payoutmdo
+      // if given then set the default values from config.json for payoutmdo
+      // prompt the input for other required:true fields
+      // 
+      // async.waterfall([
+      //   async.constant.bind(null,options),
+      //   function(options, wcb){
+          
+      //   }
+      // ])
+    }
+  };
+
+  return create;
+
+});

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     }
   ],
   "dependencies": {
+    "async": "^2.6.0",
     "cli-table": "~0.2.0",
     "commander": "~1.1.1",
+    "dargs": "^5.1.0",
     "moment": "^2.10.2",
     "openurl": "^1.1.0",
     "requirejs": "~2.1.5",


### PR DESCRIPTION
currently jira create command just considers the fields hardcoded in code. 

Motivation behind functionality : - recently jira managers in our company added some mandatory fields for creating new jira in a project. These mandatory fields mentioned whether the issue was for production or staging. Another mandatory field mentioned the component which was affected with this jira. This type of fields were not present in older jira create functionality. Neither it was extensible for such requirements.

with jira new functionality user can 

1. create issue depending on the meta configured  for project
2. jira create considers the fields marked mandatory in meta information for project and pops a question for that field if that field's default value is not configured for given alias in config.json 
3. save default values for fields in config.json and use them for faster issue creation
4. alias for jira creation which uses default values saved for alias in config.json

How does it work
jira new your_alias

1. It searches the alias in config.json file
2. If alias is found then it, picks the project from there else got 8.
3. It pulls the meta corresponding to project and finds all mandatory fields.
4. It searches all mandatory fields which it finds in config.json corresponding to alias you gave in command.
5. It prompts the user to enter value of mandatory field if no default value for that field is found in config.json
6. Next it prompts the fields which are given in __always_ask field in config.json . These fields would be asked everytime irrespective whether they are mandatory or not.
7. Create the JIRA and end.
8. Prompts the project
9. Ask the user to enter value of mandatory fields for the project.
10. creates the JIRA and end .

