### PR TITLE
Fixes process exit non zero when no error happened

### DIFF
--- a/bin/jira.js
+++ b/bin/jira.js
@@ -32,8 +32,9 @@ requirejs([
   function finalCb(err) {
     if(err){
       console.log(err.toString());
+      process.exit(1);
     }
-    process.exit(1);
+    process.exit(0);
   }
 
   program


### PR DESCRIPTION
The `finalCb` function was always calling `process.exit` with value `1`, which is interpreted as "something wrong ocurred" and displayed in some terminals like `zsh`, for example:

![ZSH terminal emulator indicates the last process exit code by showing an red "X"](https://i.imgur.com/QT6wnds.png)


This pull request only makes the `process.exit` be called with `0`, unless it identifies some error, in which case `process.exit` is called with `1`.
