### PR TITLE
Bugfix/List: duration support half hours

### DIFF
--- a/lib/jira/ls.js
+++ b/lib/jira/ls.js
@@ -105,8 +105,12 @@ define([
         return "" + (halfdays/2) + "d";
       }
       var days = Math.floor(value / secondsOneDay);
-      var hours = Math.floor((value % secondsOneDay) / 3600);
-      return "" + days + "d" + hours + "h";
+      var halfhours = Math.floor((value % secondsOneDay) / 1800);
+      if (days == 0 && halfhours == 0) {
+        return "0d"
+      }
+      return (days > 0 ? "" + days + "d" : "") +
+          (halfhours > 0 ? "" + (halfhours / 2) + "h" : "");
     },
 
     showAll: function (type, cb) {


### PR DESCRIPTION
I just contributed a feature to customize output of `jira ls` which was merged in a record time :-)

However I have since then noticed a problem when the progress was given in half hours. The formatDate method should now support it too. 