### PR TITLE
Auth: take from default config missing config.options entries

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -22,7 +22,7 @@ define([
                 config.edit_meta = configObject.edit_meta;
                 config.default_create = configObject.default_create;
                 if (!config.options || !config.options["jira_stop"]) {
-                    console.log('Ops! Seems like your ' + this.fullPath + ' is out of date. Please reset you configuration.');
+                    console.log('Oops! Seems like your ' + this.fullPath + ' is outdated. Please reset you configuration.');
                     return false;
                 } else {
                     return true;
@@ -88,6 +88,11 @@ define([
             Object.keys(defaultConfig).forEach(function (eachKey) {
                 if (!config[eachKey]) {
                     config[eachKey] = defaultConfig[eachKey];
+                }
+            });
+            Object.keys(defaultConfig.options).forEach(function (eachKey) {
+                if (!config.options[eachKey]) {
+                    config.options[eachKey] = defaultConfig.options[eachKey];
                 }
             });
             fs.writeFileSync(this.fullPath, JSON.stringify(config, null, 2));


### PR DESCRIPTION
Hi, hope you won't mind. It is just I hate delivering a failing contrib. Please find here a fix that will add update also the .options structure of the config from the default config for missing parts. It fixes by extension the issue of missing list_issues_columns.