### PR TITLE
List: duration of 0d - failing with empty cell - putting 0d

### DIFF
--- a/lib/jira/ls.js
+++ b/lib/jira/ls.js
@@ -77,8 +77,8 @@ define([
             if (value && valueSpec.truncate && typeof value === "string" && value.length > valueSpec.truncate) {
               value = value.substring(0, valueSpec.truncate - 3) + "...";
             }
-            if (value && valueSpec.isDate) {
-              value = that.formatDate(value);
+            if (valueSpec.isDate) {
+              value = that.formatDate(value); // supports null values
             }
             if (!value && valueSpec.defaultValue) {
               value = valueSpec.defaultValue;
@@ -102,18 +102,21 @@ define([
     },
 
     formatDate: function (value) {
+      if (!value) {
+        return '0d';
+      }
       var secondsOneDay = this.getWorkHoursInDay() * 3600;
       var halfdays = (2 * value) / secondsOneDay;
       if (Number.isInteger(halfdays)) {
-        return "" + (halfdays/2) + "d";
+        return '' + (halfdays/2) + 'd';
       }
       var days = Math.floor(value / secondsOneDay);
       var halfhours = Math.floor((value % secondsOneDay) / 1800);
       if (days == 0 && halfhours == 0) {
-        return "0d"
+        return '0d'
       }
-      return (days > 0 ? "" + days + "d" : "") +
-          (halfhours > 0 ? "" + (halfhours / 2) + "h" : "");
+      return (days > 0 ? '' + days + 'd' : '') +
+          (halfhours > 0 ? '' + (halfhours / 2) + 'h' : '');
     },
 
     showAll: function (type, cb) {


### PR DESCRIPTION
Sadly a little failure with the formatDate and a null value. It results in an empty cell in the table:

```
┌─────────┬────────────────┬───────────────────────────────────────┬─────────────┬──────────┬────────┐
│ Key     │ Priority       │ Summary                               │ Status      │ Estimate │ Logged │
├─────────┼────────────────┼───────────────────────────────────────┼─────────────┼──────────┼────────┤
│ PK-9451 │ To Be Assessed │ Handover                              │ Open        │ 5d       │
└─────────┴────────────────┴───────────────────────────────────────┴─────────────┴──────────┴────────┘
```

Fixing by catching the null value and putting `0d` instead:

```
┌─────────┬────────────────┬───────────────────────────────────────┬─────────────┬──────────┬────────┐
│ Key     │ Priority       │ Summary                               │ Status      │ Estimate │ Logged │
├─────────┼────────────────┼───────────────────────────────────────┼─────────────┼──────────┼────────┤
│ PK-9451 │ To Be Assessed │ Handover                              │ Open        │ 5d       │ 0d     │
└─────────┴────────────────┴───────────────────────────────────────┴─────────────┴──────────┴────────┘
```